### PR TITLE
not_nil as global method

### DIFF
--- a/lib/not_nil.rb
+++ b/lib/not_nil.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
-require "singleton"
+require 'singleton'
 
-module NotNil
-  class NotNilClass
-    include Singleton
+# Evil twin of NilClass
+class NotNilClass
+  include Singleton
 
-    def ==(other)
-      !other.nil?
-    end
+  def ==(other)
+    !other.nil?
+  end
 
-    def inspect
-      "not_nil"
-    end
+  def inspect
+    'not_nil'
   end
 end
 
-require "not_nil/object"
-extend NotNil::TopLevel
+require 'not_nil/object'

--- a/lib/not_nil/object.rb
+++ b/lib/not_nil/object.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-module NotNil
-  module TopLevel
-    def self.not_nil
-      ::NotNil::NotNilClass.instance
-    end
-  end
-end
-
+# Adds to the root in order for all objects to respond to `not_nil?`
 class Object
   def not_nil?
     !nil?
   end
+end
+
+# Adds not_nil as a global method.
+def not_nil
+  NotNilClass.instance
 end

--- a/test/test_not_nil.rb
+++ b/test/test_not_nil.rb
@@ -1,16 +1,18 @@
-require "minitest/autorun"
-require "not_nil"
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'not_nil'
 
 class NotNilTest < Minitest::Test
   def test_equals_works_for_not_nil_values
-    assert_equal true, NotNil::NotNilClass.instance == 3
+    assert_equal true, NotNilClass.instance == 3
   end
 
   def test_equals_works_for_nil_values
-    assert_equal false, NotNil::NotNilClass.instance == nil
+    assert_equal false, NotNilClass.instance == nil # rubocop:disable Style/NilComparison
   end
 
   def test_inspect
-    assert_equal "not_nil", NotNil::NotNilClass.instance.inspect
+    assert_equal 'not_nil', NotNilClass.instance.inspect
   end
 end

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -1,5 +1,7 @@
-require "minitest/autorun"
-require "not_nil"
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'not_nil'
 
 class ObjectTest < Minitest::Test
   def test_defines_not_nil_on_object
@@ -15,6 +17,6 @@ class ObjectTest < Minitest::Test
   end
 
   def test_not_nil
-    assert_equal NotNil::NotNilClass.instance, not_nil
+    assert_equal NotNilClass.instance, not_nil
   end
 end


### PR DESCRIPTION
Defining `not_nil` as a global method works just fine when the gem is required in another project