### PR TITLE
Bump version to 0.0.1

### DIFF
--- a/not_niller.gemspec
+++ b/not_niller.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'not_niller'
-  spec.version     = '0.0.0'
+  spec.version     = '0.0.1'
   spec.summary     = 'Add support for a not_nil type.'
   spec.files       = ['lib/not_niller.rb', 'lib/not_niller/object.rb']
   spec.authors     = ['Payt devs']


### PR DESCRIPTION
In this PR we are bumping the version to 0.0.1 so it won't cause any issues with bundle install any more.

After merging we need to release the new version and push this version to rubygems